### PR TITLE
ubox: fix init script validation of log_ip option

### DIFF
--- a/package/system/ubox/Makefile
+++ b/package/system/ubox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ubox
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/ubox.git

--- a/package/system/ubox/files/log.init
+++ b/package/system/ubox/files/log.init
@@ -15,7 +15,7 @@ validate_log_section()
 		'log_file:string' \
 		'log_size:uinteger' \
 		'log_hostname:string' \
-		'log_ip:ipaddr' \
+		'log_ip:host' \
 		'log_remote:bool:1' \
 		'log_port:port:514' \
 		'log_proto:or("tcp", "udp"):udp' \


### PR DESCRIPTION
The underlying logread process uses usock() to handle remote connections
which is able to handle both hostnames and IP addresses.

Ref: https://github.com/openwrt/luci/issues/5077
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(backported from commit ec83fb9ced138b7945135adffb9ff0ba63b695ec)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
